### PR TITLE
Revert "feat(helm): update chart cilium to 1.15.1"

### DIFF
--- a/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2
+++ b/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2
@@ -9,7 +9,7 @@ spec:
   # renovate: datasource=helm
   repo: https://helm.cilium.io/
   chart: cilium
-  version: 1.15.1
+  version: 1.14.6
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-

--- a/bootstrap/templates/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2.j2
+++ b/bootstrap/templates/ansible/playbooks/templates/custom-cilium-helmchart.yaml.j2.j2
@@ -10,7 +10,7 @@ spec:
   # renovate: datasource=helm
   repo: https://helm.cilium.io/
   chart: cilium
-  version: 1.15.1
+  version: 1.14.6
   targetNamespace: kube-system
   bootstrap: true
   valuesContent: |-

--- a/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
+++ b/bootstrap/templates/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml.j2
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: 1.15.1
+      version: 1.14.6
       sourceRef:
         kind: HelmRepository
         name: cilium

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: cilium
-      version: 1.15.1
+      version: 1.14.6
       sourceRef:
         kind: HelmRepository
         name: cilium


### PR DESCRIPTION
I have the following issue:
```
level=fatal msg="auto-direct-node-routes cannot be used with tunneling. Packets must be routed through the tunnel device." subsys=daemon
```

I need to check why